### PR TITLE
fix: Update slab dependency to 0.4.11

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1881,9 +1881,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "slab"
-version = "0.4.10"
+version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "04dc19736151f35336d325007ac991178d504a119863a2fcb3758cdb5e52c50d"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
 name = "smallvec"


### PR DESCRIPTION
Updates the indirect dependency 'slab' from 0.4.10 to 0.4.11 to fix a potential out-of-bounds access bug, as reported by Dependabot.