### PR TITLE
docs: READMEにオンボーディングセクションを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,24 @@
 cargo install kani-nostr-cli
 ```
 
+## 🚀 オンボーディング (Onboarding)
+
+`kani-nostr-cli` を初めて使う方のために、ウィザード形式で簡単に鍵を生成する方法を紹介します。リポジトリをクローンした直後など、まだインストールしていない場合は以下のコマンドを実行してください。
+
+```bash
+cargo run -- key generate --wizard
+```
+
+すでに `cargo install` を実行済みの場合は、以下のコマンドで実行できます。
+
+```bash
+kani-nostr-cli key generate --wizard
+```
+
+このコマンドを実行すると、対話形式でニーモニック（秘密のバックアップフレーズ）の表示、パスワードによる秘密鍵の暗号化（NIP-49）までを簡単に行うことができます。
+
+---
+
 ## 🚀 使い方 (Usage)
 
 `kani-nostr-cli` はサブコマンドベースで動作します。


### PR DESCRIPTION
README.mdに、新しいユーザーが簡単に始められるように、ウィザードを使った鍵生成の方法を説明する「オンボーディング」セクションを追加しました。

`cargo run -- key generate --wizard` コマンドを紹介し、対話形式での鍵生成プロセスを案内します。